### PR TITLE
Remove unnecessary shared_ptr

### DIFF
--- a/include/maxplus/base/analysis/mcm/mcmgraph.h
+++ b/include/maxplus/base/analysis/mcm/mcmgraph.h
@@ -211,7 +211,7 @@ public:
     calculateMaximumCycleMeanKarpDouble(const MCMnode **criticalNode = nullptr);
 
     [[nodiscard]] CDouble calculateMaximumCycleRatioAndCriticalCycleYoungTarjanOrlin(
-            std::shared_ptr<std::vector<const MCMedge*>> *cycle = nullptr);
+            std::vector<const MCMedge*> *cycle = nullptr);
 
     [[nodiscard]] std::shared_ptr<MCMgraph> normalize(CDouble mu) const;
     [[nodiscard]] std::shared_ptr<MCMgraph> normalize(const std::map<CId, CDouble> &mu) const;

--- a/include/maxplus/base/analysis/mcm/mcmyto.h
+++ b/include/maxplus/base/analysis/mcm/mcmyto.h
@@ -116,7 +116,7 @@ CDouble maxCycleMeanYoungTarjanOrlin(MCMgraph& mcmGraph);
 /// @param cycle Pointer to the critical cycle
 /// @return the MCM and a critical cycle
 CDouble
-maxCycleMeanAndCriticalCycleYoungTarjanOrlin(MCMgraph& mcmGraph, std::shared_ptr<std::vector<const MCMedge*>> *cycle);
+maxCycleMeanAndCriticalCycleYoungTarjanOrlin(MCMgraph& mcmGraph, std::vector<const MCMedge*> *cycle);
 
 
 /**
@@ -135,7 +135,7 @@ CDouble maxCycleRatioYoungTarjanOrlin(MCMgraph& mcmGraph);
  * to an array of *MCMEdges of the critical cycle/
  */
 CDouble
-maxCycleRatioAndCriticalCycleYoungTarjanOrlin(MCMgraph& mcmGraph, std::shared_ptr<std::vector<const MCMedge*>> *cycle);
+maxCycleRatioAndCriticalCycleYoungTarjanOrlin(MCMgraph& mcmGraph, std::vector<const MCMedge*> *cycle);
 
 /**
  * minCycleRatioYoungTarjanOrlin ()
@@ -153,7 +153,7 @@ CDouble minCycleRatioYoungTarjanOrlin(MCMgraph& mcmGraph);
  * to an array of *MCMEdges of the critical cycle.
  */
 CDouble
-minCycleRatioAndCriticalCycleYoungTarjanOrlin(MCMgraph& mcmGraph, std::shared_ptr<std::vector<const MCMedge*>> *cycle);
+minCycleRatioAndCriticalCycleYoungTarjanOrlin(MCMgraph& mcmGraph, std::vector<const MCMedge*> *cycle);
 
 /**
  * getDelay ()
@@ -186,7 +186,7 @@ void convertMCMgraphToYTOgraph(MCMgraph& g,
  * edges, alternatively called "length" or "weight".
  */
 
-void mmcycle(graph& gr, CDouble *lambda, std::shared_ptr<std::vector<const arc*>> *cycle);
+void mmcycle(graph& gr, CDouble *lambda, std::vector<const arc*> *cycle);
 
 } // namespace Graphs
 

--- a/src/base/analysis/mcm/mcmgraph.cc
+++ b/src/base/analysis/mcm/mcmgraph.cc
@@ -730,7 +730,7 @@ CDouble MCMgraph::calculateMaximumCycleMeanKarpDouble(const MCMnode **criticalNo
 }
 
 CDouble MCMgraph::calculateMaximumCycleRatioAndCriticalCycleYoungTarjanOrlin(
-        std::shared_ptr<std::vector<const MCMedge *>> *cycle) {
+        std::vector<const MCMedge *> *cycle) {
     return maxCycleRatioAndCriticalCycleYoungTarjanOrlin(*this, cycle);
 }
 

--- a/src/base/analysis/mcm/mcmyto.cc
+++ b/src/base/analysis/mcm/mcmyto.cc
@@ -658,7 +658,7 @@ public:
      * TODO: see if the algorithms can be unified to remove duplicate code
      **/
 
-    void mmcycle_robust(graph &gr, CDouble *lambda, std::shared_ptr<std::vector<const arc*>> *cycle) {
+    void mmcycle_robust(graph &gr, CDouble *lambda, std::vector<const arc*> *cycle) {
         const CDouble MCR_EPSILON_RATIO = 1.0e-8L;
 
         // set up initial tree
@@ -914,12 +914,12 @@ public:
         }
 
         if (cycle != nullptr) {
-            *cycle = std::make_shared<std::vector<const arc*>>();
+            *cycle = std::vector<const arc*>();
             if (min_a_ptr != NILA) {
-                (*cycle)->push_back(min_a_ptr);
+                cycle -> push_back(min_a_ptr);
                 a_ptr = min_a_ptr->tail->parent_in;
                 while (a_ptr->head != min_a_ptr->head) {
-                    (*cycle)->push_back(a_ptr);
+                    cycle -> push_back(a_ptr);
                     a_ptr = a_ptr->tail->parent_in;
                 }
             }
@@ -1078,7 +1078,7 @@ CDouble getDelay(const MCMedge& e) { return e.d; }
  */
 CDouble
 maxCycleMeanAndCriticalCycleYoungTarjanOrlin(MCMgraph &mcmGraph,
-                                             std::shared_ptr<std::vector<const MCMedge *>> *cycle) {
+                                             std::vector<const MCMedge *> *cycle) {
     graph ytoGraph;
 
     // Convert the graph to an input graph for the YTO algorithm
@@ -1088,17 +1088,17 @@ maxCycleMeanAndCriticalCycleYoungTarjanOrlin(MCMgraph &mcmGraph,
 
     CDouble min_cr = 0;
     if (cycle != nullptr) {
-        std::shared_ptr<std::vector<const arc*>> ytoCycle = nullptr;
+        std::vector<const arc*> ytoCycle;
 
         // Find maximum cycle mean
         std::int32_t ytoCycLen = 0;
         alg.mmcycle_robust(ytoGraph, &min_cr, &ytoCycle);
 
-        size_t len = ytoCycle->size();
+        size_t len = ytoCycle.size();
 
-        *cycle = std::make_shared<std::vector<const MCMedge*>>(len);
+        *cycle = std::vector<const MCMedge*>(len);
         for (uint i = 0; i < len; i++) {
-            (*cycle)->at(i) = ytoCycle->at(i)->mcmEdge;
+            (*cycle).at(i) = ytoCycle.at(i)->mcmEdge;
         }
 
     } else {
@@ -1131,14 +1131,11 @@ CDouble maxCycleMeanYoungTarjanOrlin(MCMgraph &mcmGraph) {
  */
 
 CDouble maxCycleRatioAndCriticalCycleYoungTarjanOrlin(MCMgraph &mcmGraph,
-                                                      std::shared_ptr<std::vector<const MCMedge*>> *cycle) {
+                                                      std::vector<const MCMedge*> *cycle) {
     graph ytoGraph;
 
     // catch special case when the graph has no edges
     if (mcmGraph.nrVisibleEdges() == 0) {
-        if (cycle != nullptr) {
-            *cycle = nullptr;
-        }
         return 0.0;
     }
 
@@ -1150,19 +1147,19 @@ CDouble maxCycleRatioAndCriticalCycleYoungTarjanOrlin(MCMgraph &mcmGraph,
     CDouble min_cr = 0;
     if (cycle != nullptr) {
 
-        std::shared_ptr<std::vector<const arc*>> ytoCycle = nullptr;
+        std::vector<const arc*> ytoCycle;
 
         // Find maximum cycle ratio
         std::int32_t ytoCycLen = 0;
         alg.mmcycle_robust(ytoGraph, &min_cr, &ytoCycle);
 
-        *cycle = std::make_shared<std::vector<const MCMedge *>>(ytoCycle->size());
+        *cycle = std::vector<const MCMedge *>(ytoCycle.size());
 
         // note that mmcycle returns the critical cycle following edges backwards
         // therefore reverse the order of the edges.
-        size_t len = ytoCycle->size();
+        size_t len = ytoCycle.size();
         for (uint i = 0; i < len; i++) {
-            (*cycle)->at(i) = (*ytoCycle)[len - 1 - i]->mcmEdge;
+            cycle->at(i) = ytoCycle[len - 1 - i]->mcmEdge;
         }
 
     } else {
@@ -1193,7 +1190,7 @@ CDouble maxCycleRatioYoungTarjanOrlin(MCMgraph &mcmGraph) {
  */
 
 CDouble minCycleRatioAndCriticalCycleYoungTarjanOrlin(MCMgraph &mcmGraph,
-                                                      std::shared_ptr<std::vector<const MCMedge*>> *cycle) {
+                                                      std::vector<const MCMedge*> *cycle) {
     graph ytoGraph;
 
     // Convert the graph to an input graph for the YTO algorithm
@@ -1204,18 +1201,18 @@ CDouble minCycleRatioAndCriticalCycleYoungTarjanOrlin(MCMgraph &mcmGraph,
     CDouble min_cr = 0;
     if (cycle != nullptr) {
 
-        std::shared_ptr<std::vector<const arc*>> ytoCycle = nullptr;
+        std::vector<const arc*> ytoCycle;
 
         // Find minimum cycle ratio
         std::int32_t ytoCycLen = 0;
         alg.mmcycle_robust(ytoGraph, &min_cr, &ytoCycle);
 
-        size_t len = (*ytoCycle).size();
-        *cycle = std::make_shared<std::vector<const MCMedge*>>(len);
+        size_t len = ytoCycle.size();
+        *cycle = std::vector<const MCMedge*>(len);
 
 
         for (uint i = 0; i < len; i++) {
-            (*cycle)->at(i) = (*ytoCycle)[i]->mcmEdge;
+            cycle->at(i) = ytoCycle[i]->mcmEdge;
         }
 
     } else {

--- a/src/graph/mpautomaton.cc
+++ b/src/graph/mpautomaton.cc
@@ -29,7 +29,7 @@ CDouble MaxPlusAutomatonWithRewards::calculateMCR(){
         }
     }
 
-    std::shared_ptr<std::vector<const MCMedge*>> cycle;
+    std::vector<const MCMedge*> cycle;
     CDouble mcr = maxCycleRatioAndCriticalCycleYoungTarjanOrlin(g, &cycle);
 
     return mcr;
@@ -57,11 +57,11 @@ CDouble MaxPlusAutomatonWithRewards::calculateMCRAndCycle(std::shared_ptr<std::v
         }
     }
 
-    std::shared_ptr<std::vector<const MCMedge*>> mcmCycle;
+    std::vector<const MCMedge*> mcmCycle;
     CDouble mcr = maxCycleRatioAndCriticalCycleYoungTarjanOrlin(g, &mcmCycle);
     if (cycle != nullptr) {
         *cycle = std::make_shared<std::vector<const MPAREdge*>>();
-        for (const auto *e: *mcmCycle) {
+        for (const auto *e: mcmCycle) {
             (*cycle)->push_back(edgeMap[e]);
         }
     }

--- a/src/testbench/base/mcmtest.cc
+++ b/src/testbench/base/mcmtest.cc
@@ -193,11 +193,11 @@ void MCMTest::test_yto() {
     CDouble result = maxCycleMeanYoungTarjanOrlin(g1);
     ASSERT_APPROX_EQUAL(2.5, result, 1e-5);
 
-    std::shared_ptr<std::vector<const MCMedge *>> cycle;
+    std::vector<const MCMedge *> cycle;
     result = maxCycleMeanAndCriticalCycleYoungTarjanOrlin(g1, &cycle);
     ASSERT_APPROX_EQUAL(2.5, result, 1e-5);
-    ASSERT_THROW(cycle->size() == 4);
-    int eid = cycle->at(0)->id;
+    ASSERT_THROW(cycle.size() == 4);
+    int eid = cycle.at(0)->id;
     ASSERT_THROW(eid == 0 || eid == 1 || eid == 2 || eid == 3);
 
     result = maxCycleRatioYoungTarjanOrlin(g1);
@@ -205,7 +205,7 @@ void MCMTest::test_yto() {
 
     result = maxCycleRatioAndCriticalCycleYoungTarjanOrlin(g1, &cycle);
     ASSERT_APPROX_EQUAL(10.0 / 3.0, result, 1e-5);
-    eid = cycle->at(0)->id;
+    eid = cycle.at(0)->id;
     ASSERT_THROW(eid == 4);
 
     result = minCycleRatioYoungTarjanOrlin(g1);
@@ -213,7 +213,7 @@ void MCMTest::test_yto() {
 
     result = minCycleRatioAndCriticalCycleYoungTarjanOrlin(g1, &cycle);
     ASSERT_APPROX_EQUAL(1.0, result, 1e-5);
-    eid = cycle->at(0)->id;
+    eid = cycle.at(0)->id;
     ASSERT_THROW(eid == 6);
 
     // TODO: check of the cycle ratio are identical to old SDF3


### PR DESCRIPTION
It is unnecessary to pass a shared_ptr as an argument if no copy of the shared_ptr is stored within a function.