### PR TITLE
Specify the target required c++ version

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,4 +18,5 @@ target_include_directories(maxplus PUBLIC
     ${MAXPLUSLIB_INCLUDE_DIR}/maxplus
 )
 
-
+target_compile_features(maxplus PUBLIC cxx_std_17)
+set_target_properties(maxplus PROPERTIES CXX_EXTENSIONS OFF)


### PR DESCRIPTION
Without this, the user importing the library is forced to set:

```cmake
set(CMAKE_CXX_EXTENSIONS OFF)
set(CMAKE_CXX_STANDARD 17)
```

somewhere in their project. With this, the library can be just linked with:

```cmake
target_link_libraries(<my_target> maxplus)
```

and the right c++ version is already set.